### PR TITLE
chore(release-plz): remove permissions from workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
   release-plz:
     name: Release-plz


### PR DESCRIPTION
[As stated in the documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions), the `permissions` key in a GitHub Actions workflow is for "modify[ing] the default permissions granted to the `GITHUB_TOKEN`" (the one in `secrets.GITHUB_TOKEN`).  However, the `release-plz.yml` workflow uses a dedicated personal access token instead, and so the `permissions` key in this workflow does nothing.

This PR thus removes the `permissions` key from the `release-plz.yml` workflow.  I leave it to you to update your blog post accordingly.